### PR TITLE
Support for creating multi table lookups on managed attributes

### DIFF
--- a/MscrmTools.PolymorphicLookupCreator/AppCode/MetadataManager.cs
+++ b/MscrmTools.PolymorphicLookupCreator/AppCode/MetadataManager.cs
@@ -284,7 +284,8 @@ namespace MscrmTools.PolymorphicLookupCreator.AppCode
                     {
                         Conditions =
                         {
-                            new MetadataConditionExpression("IsManaged", MetadataConditionOperator.Equals, false),
+                            // You can create extra relations on managed lookups
+                            //new MetadataConditionExpression("IsManaged", MetadataConditionOperator.Equals, false),
                             new MetadataConditionExpression("AttributeType", MetadataConditionOperator.Equals, AttributeTypeCode.Lookup)
                         }
                     }


### PR DESCRIPTION
You can add unmanaged relations on managed attributes. We need this because we ship a managed solution to our customers where we extend the lookup with tables created by the customer