### PR TITLE
Add 'TableType' as a returned property for metadata to detect if the table is 'Elastic' or not.

### DIFF
--- a/MscrmTools.PolymorphicLookupCreator/AppCode/MetadataManager.cs
+++ b/MscrmTools.PolymorphicLookupCreator/AppCode/MetadataManager.cs
@@ -301,7 +301,7 @@ namespace MscrmTools.PolymorphicLookupCreator.AppCode
                 Properties = new MetadataPropertiesExpression
                 {
                     AllProperties = false,
-                    PropertyNames = { "DisplayName", "SchemaName", "LogicalName", "PrimaryIdAttribute", "CanBePrimaryEntityInRelationship", "CanBeRelatedEntityInRelationship", "Attributes", "OneToManyRelationships", "ManyToOneRelationships" }
+                    PropertyNames = { "DisplayName", "SchemaName", "LogicalName", "PrimaryIdAttribute", "CanBePrimaryEntityInRelationship", "CanBeRelatedEntityInRelationship", "Attributes", "OneToManyRelationships", "ManyToOneRelationships", "TableType" }
                 },
                 AttributeQuery = new AttributeQueryExpression
                 {


### PR DESCRIPTION
*** Important ***
You may want to see if this will break for on-premise or earlier versions of D365.  This adds a new property of the table metadata to be returned called `TableType`. I'm not sure when this was introduced but it's necessary in order to determine if the table is `Elastic` or not.  The other option would be to set `AllProperties == true` on the call to get the table metadata.

Fixes #20 